### PR TITLE
Add missing emojis/update some existing ones

### DIFF
--- a/emojis/emojis.json
+++ b/emojis/emojis.json
@@ -783,6 +783,13 @@
           "server": "25"
         },
         {
+          "name": "Masterwork staff",
+          "emoji_name": "masterworkstaff",
+          "emoji_id": "1359114222398603365",
+          "aliases": [],
+          "server": "42"
+        },
+        {
           "name": "Merciless kiteshield",
           "emoji_name": "merciless",
           "emoji_id": "1102553021457645579",
@@ -2550,6 +2557,13 @@
           "aliases": [],
           "server": "8"
         },
+        {
+          "name": "Masterwork bow",
+          "emoji_name": "masterworkbow",
+          "emoji_id": "1359114183186321575",
+          "aliases": [],
+          "server": "42"
+        },        
         {
           "name": "Mechanised chinchompa",
           "emoji_name": "mechchin",
@@ -6894,6 +6908,13 @@
           "emoji_id": "513190159462825984",
           "aliases": [],
           "server": "1"
+        },
+        {
+          "name": "Ring of retribution",
+          "emoji_name": "ringofretribution",
+          "emoji_id": "1387866560210931722",
+          "aliases": [],
+          "server": "42"
         },
         {
           "name": "Ring of stone",
@@ -14589,6 +14610,13 @@
       "emoji_id": "580177522726273024",
       "aliases": [],
       "server": "5"
+    },
+    {
+      "name": "Soulbound lantern (Barrows)",
+      "emoji_name": "barrowssoulbound",
+      "emoji_id": "1365390498369372230",
+      "aliases": [],
+      "server": "42"
     },
     {
       "name": "3acore",

--- a/emojis/emojis.json
+++ b/emojis/emojis.json
@@ -345,7 +345,7 @@
         },
         {
           "name": "Blast diffusion boots",
-          "emoji_name": "detoboots",
+          "emoji_name": "blastdiffusion",
           "emoji_id": "602581956072439828",
           "aliases": [],
           "server": "20"
@@ -3681,11 +3681,9 @@
         },
         {
           "name": "Ek-ZekKil",
-          "emoji_name": "zekkil",
+          "emoji_name": "ezk",
           "emoji_id": "903244090953588787",
-          "aliases": [
-            "ezk"
-          ],
+          "aliases": [],
           "server": "28"
         },
         {
@@ -6257,11 +6255,12 @@
         },
         {
           "name": "Natural instinct",
-          "emoji_name": "nat",
+          "emoji_name": "naturalinstinct",
           "emoji_id": "535541258131865633",
           "aliases": [
-            "natinstinct",
-            "natty"
+            "natinstinct,
+            "natty",
+            "nat"
           ],
           "server": "17"
         },
@@ -6742,7 +6741,7 @@
           "server": "2"
         },
         {
-          "name": "Ek-ZekKil EoF",
+          "name": "Essence of Finality amulet (or)",
           "emoji_name": "eofor",
           "emoji_id": "745279787471470713",
           "aliases": [],
@@ -6791,7 +6790,7 @@
           "server": "41"
         },
         {
-          "name": "Armadyl battlestaff EoF",
+          "name": "Essence of Finality amulet (red)",
           "emoji_name": "eofredu",
           "emoji_id": "1260022281229434951",
           "aliases": [],
@@ -8345,17 +8344,23 @@
           "server": "29"
         },
         {
-          "name": "Powerburst of Acceleration",
-          "emoji_name": "accel",
+          "name": "Powerburst of acceleration",
+          "emoji_name": "powerburstofacceleration",
           "emoji_id": "756236265472524418",
-          "aliases": [],
+          "aliases": [
+            "accel",
+            "accelpot"
+          ],
           "server": "10"
         },
         {
           "name": "Powerburst of masterstroke",
-          "emoji_name": "masterstroke",
+          "emoji_name": "powerburstofmasterstroke",
           "emoji_id": "651849969338286096",
-          "aliases": [],
+          "aliases": [
+            "masterstroke",
+            "masterstrokepot"
+          ],
           "server": "20"
         },
         {
@@ -8367,9 +8372,13 @@
         },
         {
           "name": "Powerburst of vitality",
-          "emoji_name": "vitality",
+          "emoji_name": "powerburstofvitality",
           "emoji_id": "654618235097972737",
-          "aliases": [],
+          "aliases": [
+            "vitality",
+            "vitpot",
+            "vit"
+          ],
           "server": "20"
         },
         {
@@ -13380,10 +13389,12 @@
           "server": "15"
         },
         {
-          "name": "Ascension Keystone Primus",
-          "emoji_name": "keystoneprimus",
+          "name": "Ascension Keystone",
+          "emoji_name": "ascensionkeystone",
           "emoji_id": "1161265528057380904",
-          "aliases": [],
+          "aliases": [
+            "keystone"
+          ],
           "server": "40"
         },
         {

--- a/emojis/emojis.json
+++ b/emojis/emojis.json
@@ -783,6 +783,41 @@
           "server": "25"
         },
         {
+          "name": "Masterwork magic boots",
+          "emoji_name": "mwmboots",
+          "emoji_id": "1388314910311841862",
+          "aliases": [],
+          "server": "42"
+        },
+        {
+          "name": "Masterwork magic gloves",
+          "emoji_name": "mwmgloves",
+          "emoji_id": "1388314905085477057",
+          "aliases": [],
+          "server": "42"
+        },
+        {
+          "name": "Masterwork magic hat",
+          "emoji_name": "mwmhat",
+          "emoji_id": "1388314911742099576",
+          "aliases": [],
+          "server": "42"
+        },
+        {
+          "name": "Masterwork magic robe bottom",
+          "emoji_name": "mwmrobebottom",
+          "emoji_id": "1388314906671059015",
+          "aliases": [],
+          "server": "42"
+        },
+        {
+          "name": "Masterwork magic robe top",
+          "emoji_name": "mwmrobetop",
+          "emoji_id": "1388314908638183514",
+          "aliases": [],
+          "server": "42"
+        },
+        {
           "name": "Masterwork staff",
           "emoji_name": "masterworkstaff",
           "emoji_id": "1359114222398603365",

--- a/emojis/emojis.json
+++ b/emojis/emojis.json
@@ -6258,7 +6258,7 @@
           "emoji_name": "naturalinstinct",
           "emoji_id": "535541258131865633",
           "aliases": [
-            "natinstinct,
+            "natinstinct",
             "natty",
             "nat"
           ],

--- a/emojis/emojis.json
+++ b/emojis/emojis.json
@@ -7391,6 +7391,13 @@
           "server": "20"
         },
         {
+          "name": "Steel Skin",
+          "emoji_name": "steelskin",
+          "emoji_id": "1365820216545902642",
+          "aliases": [],
+          "server": "42"
+        },
+        {
           "name": "Torment",
           "emoji_name": "torment",
           "emoji_id": "583429936958930964",
@@ -8244,6 +8251,15 @@
             "burialpowder"
           ],
           "server": "31"
+        },
+        {
+          "name": "Powder of defence",
+          "emoji_name": "powderofdefence",
+          "emoji_id": "1383112489092382810",
+          "aliases": [
+            "defencepowder"
+          ],
+          "server": "42"
         },
         {
           "name": "Powder of item protection",
@@ -12356,6 +12372,13 @@
           "emoji_id": "1032552311429529661",
           "aliases": [],
           "server": "35"
+        },
+        {
+          "name": "Eastern Anachronia Teleport",
+          "emoji_name": "easternanachronia",
+          "emoji_id": "1387839803818512516",
+          "aliases": [],
+          "server": "42"
         },
         {
           "name": "Home teleport",


### PR DESCRIPTION
### Add
- Masterwork Bow <:masterworkbow:1359114183186321575> :masterworkbow:
- Masterwork Staff <:masterworkstaff:1359114222398603365> :masterworkstaff:
- Barrows Soulbound Lantern <:barrowssoulbound:1365390498369372230> :barrowssoulbound:
- Steel Skin <:steelskin:1365820216545902642> :steelskin:
- Powder of Defence <:powderofdefence:1383112489092382810> :powderofdefence:
- Eastern Anachronia Teleport <:easternanachronia:1387839803818512516> :easternanachronia:
- Ring of Retribution <:ringofretribution:1387866560210931722> :ringofretribution:
- Masterwork magic hat <:mwmhat:1388314911742099576> :mwmhat:
- Masterwork magic robe top <:mwmrobetop:1388314908638183514> :mwmrobetop:
- Masterwork magic robe bottom <:mwmrobebottom:1388314906671059015> :mwmrobebottom:
- Masterwork magic gloves <:mwmgloves:1388314905085477057> :mwmgloves:
- Masterwork magic boots <:mwmboots:1388314910311841862> :mwmboots:
### Edit
- Remove Ek-ZekKil from EoF
- Remove Armadyl battlestaff from EoF
- Natural Instinct
  - Alias nat, natty, natinstinct
- Ascension Keystone
  - Alias keystone
- Blast Diffusion Boots
- Ek-ZekKil
- Powerburst of acceleration
  - Alias accel, accelpot
- Powerburst of masterstroke
  - Alias masterstroke, masterstrokepot
- Powerburst of vitality
  - Alias vitality, vitpot, vit