### PR TITLE
Remove image field from 'Ring of retribution' emoji

### DIFF
--- a/emojis/emojis_v2.json
+++ b/emojis/emojis_v2.json
@@ -7377,7 +7377,6 @@
           "id": "ringofretribution",
           "emoji_id": "1387866560210931722",
           "emoji_server": "42",
-          "image": "5FQsCjXxp7.png",
           "preset_slot": 11,
           "preset_type": "item"
         },


### PR DESCRIPTION
Removed the image field for the 'Ring of retribution' emoji.